### PR TITLE
Increase Timeout to 40 minutes

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -202,7 +202,7 @@ jobs:
           debug: ''
       fail-fast: false
     runs-on: ${{ matrix.os }}-latest
-    timeout-minutes: 15
+    timeout-minutes: 40
 
     continue-on-error: >-
       ${{


### PR DESCRIPTION
I saw that the debugs in the multidict testing hung after reaching the debugs so I wanted to see if giving it a larger timeout would help it complete in time.